### PR TITLE
fea(func) multiple return values

### DIFF
--- a/compiler/compiler/compiler.go
+++ b/compiler/compiler/compiler.go
@@ -31,7 +31,12 @@ type Compiler struct {
 	currentPackage     *types.PackageInstance
 	currentPackageName string
 
-	contextFunc           *types.Function
+	contextFunc *types.Function
+
+	// Stack of return values pointers, is only used if a function returns more
+	// than one value
+	contextFuncRetVals [][]value.Value
+
 	contextBlock          *ir.BasicBlock
 	contextBlockVariables map[string]value.Value
 
@@ -58,6 +63,8 @@ func NewCompiler() *Compiler {
 		globalFuncs: make(map[string]*types.Function),
 
 		packages: make(map[string]*types.PackageInstance),
+
+		contextFuncRetVals: make([][]value.Value, 0),
 
 		contextLoopBreak:    make([]*ir.BasicBlock, 0),
 		contextLoopContinue: make([]*ir.BasicBlock, 0),
@@ -142,8 +149,8 @@ func (c *Compiler) addGlobal() {
 	// len_string
 	strLen := internal.StringLen(types.ModuleStringType)
 	c.globalFuncs["len_string"] = &types.Function{
-		LlvmFunction: strLen,
-		ReturnType:   types.I64,
+		LlvmFunction:   strLen,
+		LlvmReturnType: types.I64,
 	}
 	c.module.AppendFunction(strLen)
 }

--- a/compiler/compiler/external_funcs.go
+++ b/compiler/compiler/external_funcs.go
@@ -29,18 +29,18 @@ func (c *Compiler) createExternalPackage() {
 		printfFunc.Sig.Variadic = true
 
 		c.externalFuncs.Printf = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "printf",
-			LlvmFunction: printfFunc,
-			IsExternal:   true,
+			LlvmReturnType: types.Void,
+			FunctionName:   "printf",
+			LlvmFunction:   printfFunc,
+			IsExternal:     true,
 		}
 		externalPackageFuncs["Printf"] = c.externalFuncs.Printf
 	}
 
 	{
 		c.externalFuncs.Malloc = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "malloc",
+			LlvmReturnType: types.Void,
+			FunctionName:   "malloc",
 			LlvmFunction: c.module.NewFunction("malloc",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("", i64.LLVM()),
@@ -52,8 +52,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Realloc = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "realloc",
+			LlvmReturnType: types.Void,
+			FunctionName:   "realloc",
 			LlvmFunction: c.module.NewFunction("realloc",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("", llvmTypes.NewPointer(i8.LLVM())),
@@ -66,8 +66,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Memcpy = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "memcpy",
+			LlvmReturnType: types.Void,
+			FunctionName:   "memcpy",
 			LlvmFunction: c.module.NewFunction("memcpy",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("dest", llvmTypes.NewPointer(i8.LLVM())),
@@ -81,8 +81,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Strcat = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "strcat",
+			LlvmReturnType: types.Void,
+			FunctionName:   "strcat",
 			LlvmFunction: c.module.NewFunction("strcat",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("", llvmTypes.NewPointer(i8.LLVM())),
@@ -95,8 +95,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Strcpy = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "strcpy",
+			LlvmReturnType: types.Void,
+			FunctionName:   "strcpy",
 			LlvmFunction: c.module.NewFunction("strcpy",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("", llvmTypes.NewPointer(i8.LLVM())),
@@ -109,8 +109,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Strncpy = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "strncpy",
+			LlvmReturnType: types.Void,
+			FunctionName:   "strncpy",
 			LlvmFunction: c.module.NewFunction("strncpy",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("", llvmTypes.NewPointer(i8.LLVM())),
@@ -124,8 +124,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Strndup = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "strndup",
+			LlvmReturnType: types.Void,
+			FunctionName:   "strndup",
 			LlvmFunction: c.module.NewFunction("strndup",
 				llvmTypes.NewPointer(i8.LLVM()),
 				ir.NewParam("", llvmTypes.NewPointer(i8.LLVM())),
@@ -138,8 +138,8 @@ func (c *Compiler) createExternalPackage() {
 
 	{
 		c.externalFuncs.Exit = &types.Function{
-			ReturnType:   types.Void,
-			FunctionName: "exit",
+			LlvmReturnType: types.Void,
+			FunctionName:   "exit",
 			LlvmFunction: c.module.NewFunction("exit",
 				llvmTypes.Void,
 				ir.NewParam("", i32.LLVM()),

--- a/compiler/compiler/func_len.go
+++ b/compiler/compiler/func_len.go
@@ -22,7 +22,7 @@ func (c *Compiler) lenFuncCall(v parser.CallNode) value.Value {
 
 		return value.Value{
 			Value:      c.contextBlock.NewCall(f.LlvmFunction, val),
-			Type:       f.ReturnType,
+			Type:       f.LlvmReturnType,
 			IsVariable: false,
 		}
 	}

--- a/compiler/compiler/types/type.go
+++ b/compiler/compiler/types/type.go
@@ -105,8 +105,13 @@ func (m Method) Name() string {
 type Function struct {
 	backingType
 
-	LlvmFunction  llvmValue.Named
-	ReturnType    Type
+	LlvmFunction llvmValue.Named
+
+	// The return type of the LLVM function (is always 1)
+	LlvmReturnType Type
+	// Return types of the Tre function
+	ReturnTypes []Type
+
 	FunctionName  string
 	IsVariadic    bool
 	ArgumentTypes []Type

--- a/compiler/parser/node.go
+++ b/compiler/parser/node.go
@@ -186,11 +186,11 @@ func (n MultiNameNode) String() string {
 type ReturnNode struct {
 	baseNode
 
-	Val Node
+	Vals []Node
 }
 
 func (rn ReturnNode) String() string {
-	return fmt.Sprintf("return(%v)", rn.Val)
+	return fmt.Sprintf("return(%v)", rn.Vals)
 }
 
 // AllocNode creates a new variable Name with the value Val

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -324,7 +324,28 @@ func (p *parser) parseOne(withAheadParse bool) (res Node) {
 		// "return" creates a ReturnNode
 		if current.Val == "return" {
 			p.i++
-			res = ReturnNode{Val: p.parseOne(true)}
+
+			var retVals []Node
+
+			for {
+				checkIfEOL := p.lookAhead(0)
+				if checkIfEOL.Type == lexer.EOL {
+					break
+				}
+
+				retVals = append(retVals, p.parseOne(true))
+				p.i++
+
+				checkIfComma := p.lookAhead(0)
+				if checkIfComma.Type == lexer.SEPARATOR && checkIfComma.Val == "," {
+					p.i++
+					continue
+				}
+
+				break
+			}
+
+			res = ReturnNode{Vals: retVals}
 			if withAheadParse {
 				res = p.aheadParse(res)
 			}

--- a/compiler/testdata/func-multi-ret.go
+++ b/compiler/testdata/func-multi-ret.go
@@ -1,11 +1,13 @@
 package main
 
+import "external"
+
 func otherfunc() (int, int) {
-	// return 100, 200
-	return 0, 0
+	return 100, 200
 }
 
 func main() {
-	otherfunc()
-
+	a, b := otherfunc()
+	external.Printf("a: %d\n", a) // a: 100
+	external.Printf("b: %d\n", b) // b: 200
 }

--- a/compiler/testdata/func-multi-ret.go
+++ b/compiler/testdata/func-multi-ret.go
@@ -1,0 +1,11 @@
+package main
+
+func otherfunc() (int, int) {
+	// return 100, 200
+	return 0, 0
+}
+
+func main() {
+	otherfunc()
+
+}


### PR DESCRIPTION
### This PR adds support for

- Functions with multiple return values
- Return statements with multiple values

### Implementation details

LLVM functions have exactly one return type, to bypass this functions with more than 1 return value
now returns values via argument pointers, and the LLVM function will return void.

The tre code:

```go
func otherfunc() (int, int) {
	return 100, 200
}

func main() {
	a, b := otherfunc()
}
```

is compiled as:

```llvm
define void @main_otherfunc(i64* %ret-0, i64* %ret-1) {
block-2:
	store i64 100, i64* %ret-0
	store i64 200, i64* %ret-1
	ret void
}

define i32 @main() {
block-3:
	%0 = alloca i64
	%1 = alloca i64
	call void @main_otherfunc(i64* %0, i64* %1)
}
```