### PR TITLE
Variable swap

### DIFF
--- a/compiler/compiler/alloc.go
+++ b/compiler/compiler/alloc.go
@@ -112,6 +112,14 @@ func (c *Compiler) compileAssignNode(v *parser.AssignNode) {
 	tmpStores := make([]llvmValue.Value, len(v.Target))
 	realTargets := make([]value.Value, len(v.Target))
 
+	// Skip temporary variables if we're assigning to one single var
+	if len(v.Target) == 1 {
+		dst := c.compileValue(v.Target[0])
+		s := c.compileSingleAssign(dst.Type, dst, v.Val[0])
+		c.contextBlock.NewStore(s, dst.Value)
+		return
+	}
+
 	for i := range v.Target {
 		target := v.Target[i]
 

--- a/compiler/compiler/compiler.go
+++ b/compiler/compiler/compiler.go
@@ -307,8 +307,6 @@ func (c *Compiler) compileValue(node parser.Node) value.Value {
 		return c.compileDefineFuncNode(v)
 	case *parser.InitializeArrayNode:
 		return c.compileInitializeArrayNode(v)
-	case *parser.MultiValueNode:
-		return c.compileMultiValueNode(v)
 	case *parser.DecrementNode:
 		return c.compileDecrementNode(v)
 	case *parser.IncrementNode:

--- a/compiler/compiler/for.go
+++ b/compiler/compiler/for.go
@@ -140,12 +140,12 @@ func (c *Compiler) compileForRange(v *parser.ForNode) {
 		},
 
 		AfterIteration: &parser.AssignNode{
-			Target: &parser.NameNode{Name: forKeyName},
-			Val: &parser.OperatorNode{
+			Target: []parser.Node{&parser.NameNode{Name: forKeyName}},
+			Val: []parser.Node{&parser.OperatorNode{
 				Left:     &parser.NameNode{Name: forKeyName},
 				Operator: parser.OP_ADD,
 				Right:    &parser.ConstantNode{Type: parser.NUMBER, Value: 1},
-			},
+			}},
 		},
 
 		Block: modifiedBlock,

--- a/compiler/compiler/for.go
+++ b/compiler/compiler/for.go
@@ -71,7 +71,7 @@ func (c *Compiler) compileForRange(v *parser.ForNode) {
 	var rangeItem parser.Node
 
 	if forAlloc, ok := v.BeforeLoop.(*parser.AllocNode); ok {
-		forAllocRange := forAlloc.Val.(*parser.RangeNode)
+		forAllocRange := forAlloc.Val[0].(*parser.RangeNode)
 		rangeItem = forAllocRange.Item
 	} else if forRange, ok := v.BeforeLoop.(*parser.RangeNode); ok {
 		rangeItem = forRange.Item
@@ -82,42 +82,38 @@ func (c *Compiler) compileForRange(v *parser.ForNode) {
 	// Alloc the value of rangeItem and save it in a variable
 	rangeItemName := name.Var("range-item")
 	c.compileAllocNode(&parser.AllocNode{
-		Name: rangeItemName,
-		Val:  rangeItem,
+		Name: []string{rangeItemName},
+		Val:  []parser.Node{rangeItem},
 	})
 
 	// Call and alloc len() and save it in a variable
 	forItemLenName := name.Var("range-item-len")
 	c.compileAllocNode(&parser.AllocNode{
-		Name: forItemLenName,
-		Val: &parser.CallNode{
+		Name: []string{forItemLenName},
+		Val: []parser.Node{&parser.CallNode{
 			Function:  &parser.NameNode{Name: "len"},
 			Arguments: []parser.Node{&parser.NameNode{Name: rangeItemName}},
-		},
+		}},
 	})
 
 	forKeyName := name.Var("for-key")
 
 	// Ranges that use the key and value
 	if forAlloc, ok := v.BeforeLoop.(*parser.AllocNode); ok {
-		var keyName string
-		if forAlloc.MultiNames == nil {
-			keyName = forAlloc.Name
-		} else {
-			keyName = forAlloc.MultiNames.Names[0].Name
-		}
+		keyName := forAlloc.Name[0]
 
 		// Assignment of key
 		modifiedBlock = append(modifiedBlock, &parser.AllocNode{
-			Name: keyName,
-			Val:  &parser.NameNode{Name: forKeyName},
+			Name: []string{keyName},
+			Val:  []parser.Node{&parser.NameNode{Name: forKeyName}},
 		})
 
 		// Assignment of value
-		if forAlloc.MultiNames != nil && len(forAlloc.MultiNames.Names) >= 2 {
+
+		if len(forAlloc.Name) >= 2 {
 			modifiedBlock = append(modifiedBlock, &parser.AllocNode{
-				Name: forAlloc.MultiNames.Names[1].Name,
-				Val:  &parser.LoadArrayElement{Array: &parser.NameNode{Name: rangeItemName}, Pos: &parser.NameNode{Name: forKeyName}},
+				Name: []string{forAlloc.Name[1]},
+				Val:  []parser.Node{&parser.LoadArrayElement{Array: &parser.NameNode{Name: rangeItemName}, Pos: &parser.NameNode{Name: forKeyName}}},
 			})
 		}
 	}
@@ -129,7 +125,7 @@ func (c *Compiler) compileForRange(v *parser.ForNode) {
 	}
 
 	c.compileForThreeType(&parser.ForNode{
-		BeforeLoop: &parser.AllocNode{Name: forKeyName, Val: &parser.ConstantNode{Type: parser.NUMBER, Value: 0}},
+		BeforeLoop: &parser.AllocNode{Name: []string{forKeyName}, Val: []parser.Node{&parser.ConstantNode{Type: parser.NUMBER, Value: 0}}},
 
 		Condition: &parser.OperatorNode{
 			Left:     typeCastedKey,

--- a/compiler/compiler/func.go
+++ b/compiler/compiler/func.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+
 	"github.com/llir/llvm/ir"
 	"github.com/llir/llvm/ir/constant"
 	llvmTypes "github.com/llir/llvm/ir/types"
@@ -164,9 +165,9 @@ func (c *Compiler) compileDefineFuncNode(v *parser.DefineFuncNode) value.Value {
 
 		for i, retType := range treParams[:argumentReturnValuesCount] {
 			retVals = append(retVals, value.Value{
-				Value: llvmParams[i],
-				Type:  retType,
-				IsVariable: false,
+				Value:      llvmParams[i],
+				Type:       retType,
+				IsVariable: true,
 			})
 		}
 
@@ -216,8 +217,8 @@ func (c *Compiler) compileDefineFuncNode(v *parser.DefineFuncNode) value.Value {
 		r := v.ReturnValues[0]
 		all := c.contextBlock.NewAlloca(funcRetType.LLVM())
 		retVar := value.Value{
-			Value: all,
-			Type: funcRetType,
+			Value:      all,
+			Type:       funcRetType,
 			IsVariable: true,
 		}
 		c.setVar(r.Name, retVar)
@@ -334,7 +335,6 @@ func (c *Compiler) compileReturnNode(v *parser.ReturnNode) {
 		c.contextBlock.NewRet(nil)
 		return
 	}
-
 
 	// Naked return, func has one named return variable
 	if len(v.Vals) == 0 {

--- a/compiler/parser/multi_assign_test.go
+++ b/compiler/parser/multi_assign_test.go
@@ -42,16 +42,56 @@ func TestMultiAssignVar(t *testing.T) {
 	}
 
 	expected := FileNode{
-
 		Instructions: []Node{
 			&DeclarePackageNode{PackageName: "main"},
 			&DefineFuncNode{Name: "main", IsNamed: true,
 				Body: []Node{
-					&AllocNode{Name: "a", Val: &ConstantNode{Type: NUMBER, Value: 100}},
-					&AllocNode{Name: "b", Val: &ConstantNode{Type: NUMBER, Value: 200}},
+					&AllocNode{Name: []string{"a"}, Val: []Node{&ConstantNode{Type: NUMBER, Value: 100}}},
+					&AllocNode{Name: []string{"b"}, Val: []Node{&ConstantNode{Type: NUMBER, Value: 200}}},
 					&AssignNode{
 						Target: []Node{&NameNode{Name: "a"}, &NameNode{Name: "b"}},
 						Val:    []Node{&ConstantNode{Type: NUMBER, Value: 300}, &ConstantNode{Type: NUMBER, Value: 400}},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, Parse(input, false))
+}
+func TestMultiAllocVar(t *testing.T) {
+	input := []lexer.Item{
+		{Type: lexer.KEYWORD, Val: "package", Line: 1},
+		{Type: lexer.IDENTIFIER, Val: "main", Line: 1},
+		{Type: lexer.EOL, Val: "", Line: 1},
+		{Type: lexer.EOL, Val: "", Line: 2},
+		{Type: lexer.KEYWORD, Val: "func", Line: 3},
+		{Type: lexer.IDENTIFIER, Val: "main", Line: 3},
+		{Type: lexer.SEPARATOR, Val: "(", Line: 3},
+		{Type: lexer.SEPARATOR, Val: ")", Line: 3},
+		{Type: lexer.SEPARATOR, Val: "{", Line: 3},
+		{Type: lexer.EOL, Val: "", Line: 3},
+		{Type: lexer.IDENTIFIER, Val: "a", Line: 6},
+		{Type: lexer.SEPARATOR, Val: ",", Line: 6},
+		{Type: lexer.IDENTIFIER, Val: "b", Line: 6},
+		{Type: lexer.OPERATOR, Val: ":=", Line: 6},
+		{Type: lexer.NUMBER, Val: "300", Line: 6},
+		{Type: lexer.SEPARATOR, Val: ",", Line: 6},
+		{Type: lexer.NUMBER, Val: "400", Line: 6},
+		{Type: lexer.EOL, Val: "", Line: 6},
+		{Type: lexer.SEPARATOR, Val: "}", Line: 7},
+		{Type: lexer.EOL, Val: "", Line: 7},
+		{Type: lexer.EOF, Val: "", Line: 0},
+	}
+
+	expected := FileNode{
+		Instructions: []Node{
+			&DeclarePackageNode{PackageName: "main"},
+			&DefineFuncNode{Name: "main", IsNamed: true,
+				Body: []Node{
+					&AllocNode{
+						Name: []string{"a", "b"},
+						Val:  []Node{&ConstantNode{Type: NUMBER, Value: 300}, &ConstantNode{Type: NUMBER, Value: 400}},
 					},
 				},
 			},

--- a/compiler/parser/multi_assign_test.go
+++ b/compiler/parser/multi_assign_test.go
@@ -1,0 +1,62 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zegl/tre/compiler/lexer"
+)
+
+func TestMultiAssignVar(t *testing.T) {
+	input := []lexer.Item{
+		{Type: lexer.KEYWORD, Val: "package", Line: 1},
+		{Type: lexer.IDENTIFIER, Val: "main", Line: 1},
+		{Type: lexer.EOL, Val: "", Line: 1},
+		{Type: lexer.EOL, Val: "", Line: 2},
+		{Type: lexer.KEYWORD, Val: "func", Line: 3},
+		{Type: lexer.IDENTIFIER, Val: "main", Line: 3},
+		{Type: lexer.SEPARATOR, Val: "(", Line: 3},
+		{Type: lexer.SEPARATOR, Val: ")", Line: 3},
+		{Type: lexer.SEPARATOR, Val: "{", Line: 3},
+		{Type: lexer.EOL, Val: "", Line: 3},
+		{Type: lexer.IDENTIFIER, Val: "a", Line: 4},
+		{Type: lexer.OPERATOR, Val: ":=", Line: 4},
+		{Type: lexer.NUMBER, Val: "100", Line: 4},
+		{Type: lexer.EOL, Val: "", Line: 4},
+		{Type: lexer.IDENTIFIER, Val: "b", Line: 5},
+		{Type: lexer.OPERATOR, Val: ":=", Line: 5},
+		{Type: lexer.NUMBER, Val: "200", Line: 5},
+		{Type: lexer.EOL, Val: "", Line: 5},
+		{Type: lexer.IDENTIFIER, Val: "a", Line: 6},
+		{Type: lexer.SEPARATOR, Val: ",", Line: 6},
+		{Type: lexer.IDENTIFIER, Val: "b", Line: 6},
+		{Type: lexer.OPERATOR, Val: "=", Line: 6},
+		{Type: lexer.NUMBER, Val: "300", Line: 6},
+		{Type: lexer.SEPARATOR, Val: ",", Line: 6},
+		{Type: lexer.NUMBER, Val: "400", Line: 6},
+		{Type: lexer.EOL, Val: "", Line: 6},
+		{Type: lexer.SEPARATOR, Val: "}", Line: 7},
+		{Type: lexer.EOL, Val: "", Line: 7},
+		{Type: lexer.EOF, Val: "", Line: 0},
+	}
+
+	expected := FileNode{
+
+		Instructions: []Node{
+			&DeclarePackageNode{PackageName: "main"},
+			&DefineFuncNode{Name: "main", IsNamed: true,
+				Body: []Node{
+					&AllocNode{Name: "a", Val: &ConstantNode{Type: NUMBER, Value: 100}},
+					&AllocNode{Name: "b", Val: &ConstantNode{Type: NUMBER, Value: 200}},
+					&AssignNode{
+						Target: []Node{&NameNode{Name: "a"}, &NameNode{Name: "b"}},
+						Val:    []Node{&ConstantNode{Type: NUMBER, Value: 300}, &ConstantNode{Type: NUMBER, Value: 400}},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, Parse(input, false))
+}

--- a/compiler/parser/node.go
+++ b/compiler/parser/node.go
@@ -235,8 +235,8 @@ func (an AllocNode) String() string {
 type AssignNode struct {
 	baseNode
 
-	Target Node
-	Val    Node
+	Target []Node
+	Val    []Node
 }
 
 func (an AssignNode) String() string {
@@ -432,7 +432,7 @@ func (i TypeCastInterfaceNode) String() string {
 }
 
 // A node that contains multiple nodes
-// The right hand side of "a, b := 1, 2" is a MultiNode
+// The right hand side of "a, b := 1, 2" is a MultiValueNode
 type MultiValueNode struct {
 	baseNode
 	Items []Node

--- a/compiler/parser/node.go
+++ b/compiler/parser/node.go
@@ -216,18 +216,13 @@ func (rn ReturnNode) String() string {
 type AllocNode struct {
 	baseNode
 
-	Name       string
-	MultiNames *MultiNameNode
-	Escapes    bool
+	Escapes bool
 
-	Val Node
+	Name []string
+	Val  []Node
 }
 
 func (an AllocNode) String() string {
-	if an.MultiNames != nil && len(an.MultiNames.Names) > 0 {
-		return fmt.Sprintf("allocMulti(%+v) = %v", an.MultiNames, an.Val)
-	}
-
 	return fmt.Sprintf("alloc(%s) = %v (escapes: %v)", an.Name, an.Val, an.Escapes)
 }
 
@@ -429,17 +424,6 @@ type TypeCastInterfaceNode struct {
 
 func (i TypeCastInterfaceNode) String() string {
 	return fmt.Sprintf("castInterface(%s(%+v))", i.Type, i.Item)
-}
-
-// A node that contains multiple nodes
-// The right hand side of "a, b := 1, 2" is a MultiValueNode
-type MultiValueNode struct {
-	baseNode
-	Items []Node
-}
-
-func (m MultiValueNode) String() string {
-	return fmt.Sprintf("multi(%+v)", m.Items)
 }
 
 type DecrementNode struct {

--- a/compiler/passes/escape/escape.go
+++ b/compiler/passes/escape/escape.go
@@ -17,12 +17,8 @@ func Escape(input parser.FileNode) parser.FileNode {
 
 				// Find all variables allocated in this function
 				if allocIns, ok := ins.(*parser.AllocNode); ok {
-					if allocIns.MultiNames != nil && len(allocIns.MultiNames.Names) > 0 {
-						for _, name := range allocIns.MultiNames.Names {
-							allocatedVars[name.Name] = insIndex
-						}
-					} else {
-						allocatedVars[allocIns.Name] = insIndex
+					for _, name := range allocIns.Name {
+						allocatedVars[name] = insIndex
 					}
 				}
 

--- a/compiler/passes/escape/escape_test.go
+++ b/compiler/passes/escape/escape_test.go
@@ -19,8 +19,8 @@ func escapeTest(t *testing.T, input string, expected map[string]bool) {
 		if defFuncNode, ok := ins.(*parser.DefineFuncNode); ok {
 			for _, ins := range defFuncNode.Body {
 				if allocNode, ok := ins.(*parser.AllocNode); ok {
-					allocsChecked = append(allocsChecked, allocNode.Name)
-					assert.Equal(t, expected[allocNode.Name], allocNode.Escapes, allocNode.Name)
+					allocsChecked = append(allocsChecked, allocNode.Name[0])
+					assert.Equal(t, expected[allocNode.Name[0]], allocNode.Escapes, allocNode.Name)
 				}
 			}
 		}
@@ -94,22 +94,22 @@ func TestEscapesStructPointer(t *testing.T) {
 
 func TestEscapeNestedStruct(t *testing.T) {
 	escapeTest(t, `package main
-	
+
 		type Bar struct {
 			num int64
 		}
-		
+
 		type Foo struct {
 			num int64
 			bar *Bar
 		}
-		
+
 		func GetFooPtr() *Foo {
 			f := Foo{
 				num: 300,
 				bar: &Bar{num: 400},
 			}
-		
+
 			return &f
 		}`,
 		map[string]bool{

--- a/compiler/testdata/var-swap.go
+++ b/compiler/testdata/var-swap.go
@@ -1,0 +1,23 @@
+package main
+
+import "external"
+
+func main() {
+	a := 100
+	b := 200
+
+	// 100 200
+	external.Printf("%d %d\n", a, b)
+
+	b, a = a, b
+
+	// 200 100
+	external.Printf("%d %d\n", a, b)
+
+	c := 111
+	d := 222
+	a, b = c, d
+
+	// 111 222
+	external.Printf("%d %d\n", a, b)
+}


### PR DESCRIPTION
This fixes #119

This adds support for swapping variables on the form:

```go
b, a = a, b
```