### PR TITLE
compiler: handle calls to func the same way

### DIFF
--- a/compiler/testdata/struct-func.go
+++ b/compiler/testdata/struct-func.go
@@ -1,0 +1,18 @@
+package main
+
+import "external"
+
+type a struct {
+	fn func(int) int
+}
+
+func main() {
+	v := a{
+		fn: func(a int) int {
+			return a + 1
+		},
+	}
+
+	// 3
+	external.Printf("%d\n", v.fn(2))
+}


### PR DESCRIPTION
compiler: handle calls to func the same way, no matter how the Function was resolved.

Previous refactorings of compileCallNode() allowed this simplification

Fixes #148 